### PR TITLE
Fix code scanning alert no. 3: Incorrect conversion between integer types

### DIFF
--- a/internal/helpers/database/database.go
+++ b/internal/helpers/database/database.go
@@ -38,6 +38,11 @@ func FetchDatabaseData(ctx context.Context, dbcr *kindav1beta1.Database, dbCred 
 		log.Error(err, "can't get port information from the instanceRef")
 		return nil, nil, err
 	}
+	if port < 0 || port > 65535 {
+		err := fmt.Errorf("port value out of range: %d", port)
+		log.Error(err, "port value is out of the valid range (0-65535)")
+		return nil, nil, err
+	}
 
 	backend, err := instance.GetBackendType()
 	if err != nil {


### PR DESCRIPTION
Fixes [https://github.com/datacosmos-br/db-operator/security/code-scanning/3](https://github.com/datacosmos-br/db-operator/security/code-scanning/3)

To fix the problem, we need to ensure that the `port` value is within the valid range for a `uint16` type before performing the conversion. This can be done by adding a bounds check after parsing the integer value. If the value is out of bounds, we should handle the error appropriately.

1. Parse the `port` value using `strconv.Atoi` as before.
2. Add a check to ensure the parsed value is within the range of `0` to `65535`.
3. If the value is within the range, proceed with the conversion to `uint16`.
4. If the value is out of bounds, log an error and return an appropriate error response.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
