### PR TITLE
feat(database): spec.databaseName para nome de banco explícito

### DIFF
--- a/api/v1beta1/database_types.go
+++ b/api/v1beta1/database_types.go
@@ -41,6 +41,11 @@ type DatabaseSpec struct {
 	// User will not be removed, when a database is removed, but the permissions added by the
 	// operator will be cleaned up
 	ExistingUser string `json:"existingUser,omitempty"`
+	// DatabaseName overrides the name of the database that gets created. When
+	// empty, the operator generates it as "<namespace>-<name>". Set it to
+	// adopt a pre-existing database or to keep an externally-defined name.
+	// +optional
+	DatabaseName string `json:"databaseName,omitempty"`
 }
 
 type ExtraGrant struct {

--- a/config/crd/bases/kinda.rocks_databases.yaml
+++ b/config/crd/bases/kinda.rocks_databases.yaml
@@ -480,6 +480,12 @@ spec:
                       type: object
                     type: array
                 type: object
+              databaseName:
+                description: |-
+                  DatabaseName overrides the name of the database that gets created. When
+                  empty, the operator generates it as "<namespace>-<name>". Set it to
+                  adopt a pre-existing database or to keep an externally-defined name.
+                type: string
               deletionProtected:
                 type: boolean
               existingUser:

--- a/internal/controller/database_controller.go
+++ b/internal/controller/database_controller.go
@@ -1095,7 +1095,7 @@ func (r *DatabaseReconciler) manageError(ctx context.Context, dbcr *kindav1beta1
 
 func (r *DatabaseReconciler) createSecret(ctx context.Context, dbcr *kindav1beta1.Database) (*corev1.Secret, error) {
 	log := log.FromContext(ctx)
-	secretData, err := dbhelper.GenerateDatabaseSecretData(dbcr.ObjectMeta, dbcr.Status.Engine, "", dbcr.Spec.ExistingUser)
+	secretData, err := dbhelper.GenerateDatabaseSecretData(dbcr.ObjectMeta, dbcr.Status.Engine, dbcr.Spec.DatabaseName, dbcr.Spec.ExistingUser)
 	if err != nil {
 		log.Error(err, "can not generate credentials for database")
 		return nil, err

--- a/internal/controller/dbuser_controller.go
+++ b/internal/controller/dbuser_controller.go
@@ -101,7 +101,12 @@ func (r *DbUserReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		// If a secret is not found on the "delete" event it should be a critical unrecoverable
 		// error, cause we don't know which user must be removed
 		if k8serrors.IsNotFound(err) && !dbusercr.IsDeleted() {
-			dbName := fmt.Sprintf("%s-%s", dbusercr.Namespace, dbusercr.Spec.DatabaseRef)
+			// Match the referenced Database's name: an explicit spec.databaseName
+			// wins, otherwise fall back to the generated "<namespace>-<ref>".
+			dbName := dbcr.Spec.DatabaseName
+			if dbName == "" {
+				dbName = fmt.Sprintf("%s-%s", dbusercr.Namespace, dbusercr.Spec.DatabaseRef)
+			}
 			secretData, err := dbhelper.GenerateDatabaseSecretData(dbusercr.ObjectMeta, dbcr.Status.Engine, dbName, dbusercr.Spec.ExistingUser)
 			if err != nil {
 				log.Error(err, "Could not generate credentials for database")

--- a/internal/webhook/v1beta1/database_webhook.go
+++ b/internal/webhook/v1beta1/database_webhook.go
@@ -122,6 +122,10 @@ func (v *DatabaseCustomValidator) ValidateCreate(_ context.Context, obj *kindaro
 		return warnings, err
 	}
 
+	if obj.Spec.DatabaseName != "" && !isValidIdentifier(obj.Spec.DatabaseName) {
+		return warnings, fmt.Errorf("databaseName is not a valid identifier: %s", obj.Spec.DatabaseName)
+	}
+
 	return warnings, nil
 }
 
@@ -179,6 +183,10 @@ func (v *DatabaseCustomValidator) ValidateUpdate(_ context.Context, oldObj, newO
 
 	if err := validateClickhouseDatabase(newObj.Spec.Clickhouse); err != nil {
 		return warnings, err
+	}
+
+	if newObj.Spec.DatabaseName != oldObj.Spec.DatabaseName {
+		return warnings, fmt.Errorf(immutableErr, "spec.databaseName")
 	}
 
 	return warnings, nil


### PR DESCRIPTION
Adiciona `Database.spec.databaseName` (opcional, imutável) para o operator adotar um nome de banco pré-existente em vez de gerar `<namespace>-<name>`. Necessário para migrar tenants ClickHouse legados (`otel_<tenant>`/`pmm_<tenant>`) ao db-operator sem renomear/migrar dados. Validado como identificador pelo webhook; honrado também pelo DbUser controller. Gates: build/lint(0)/unit-test verdes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional `databaseName` field to Database resources, enabling users to specify custom database names. When the field is not specified, the system defaults to the standard namespace-resource naming format. The field is validated to ensure it contains a valid identifier and becomes immutable once the Database resource is created.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/datacosmos-br/db-operator/pull/75?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->