### PR TITLE
fix(database): GetSSLMode trata engine clickhouse

### DIFF
--- a/internal/helpers/database/database.go
+++ b/internal/helpers/database/database.go
@@ -288,6 +288,17 @@ func GetSSLMode(dbcr *kindav1beta1.Database, instance *kindav1beta1.DbInstance) 
 		}
 	}
 
+	if dbcr.Status.Engine == "clickhouse" {
+		switch genericSSL {
+		case consts.SSL_DISABLED:
+			return "none", nil
+		case consts.SSL_REQUIRED:
+			return "require", nil
+		case consts.SSL_VERIFY_CA:
+			return "verify-ca", nil
+		}
+	}
+
 	return "", fmt.Errorf("unknown database engine: %s", dbcr.Status.Engine)
 }
 


### PR DESCRIPTION
handleInfoConfigMap aborta a reconciliação do Database ClickHouse com 'unknown database engine: clickhouse' (GetSSLMode só conhecia postgres/mysql) — credentials.templates nunca eram aplicados. Fix: branch clickhouse em GetSSLMode. Gates verdes.