### PR TITLE
fix(kube): always own generated objects for ArgoCD; orphan on cleanup-disabled delete

### DIFF
--- a/internal/controller/database_controller.go
+++ b/internal/controller/database_controller.go
@@ -446,12 +446,6 @@ func (r *DatabaseReconciler) handleDbDelete(ctx context.Context, dbcr *kindav1be
 			// when database deletion failed, don't requeue request. to prevent exceeding api limit (ex: against google api)
 			return r.manageError(ctx, dbcr, err, false, phase)
 		}
-		kci.RemoveFinalizer(&dbcr.ObjectMeta, "db."+dbcr.Name)
-		err = r.Update(ctx, dbcr)
-		if err != nil {
-			log.Error(err, "error resource updating")
-			return r.manageError(ctx, dbcr, err, true, phase)
-		}
 	}
 	// A temporary check that exists to avoid creating templates if secretsTemplates are used.
 	// todo: It should be removed when secretsTemlates are gone
@@ -485,6 +479,18 @@ func (r *DatabaseReconciler) handleDbDelete(ctx context.Context, dbcr *kindav1be
 		}
 	} else {
 		if err := r.kubeHelper.ModifyObject(ctx, dbSecret); err != nil {
+			return r.manageError(ctx, dbcr, err, true, phase)
+		}
+	}
+
+	// Remove the finalizer only after every generated object has been handled
+	// (orphaned when cleanup is disabled, released otherwise). Removing it
+	// earlier would let the owner CR be deleted and the garbage collector
+	// cascade-delete the still-owned Secret/ConfigMap before they are orphaned.
+	if commonhelper.ContainsString(dbcr.Finalizers, "db."+dbcr.Name) {
+		kci.RemoveFinalizer(&dbcr.ObjectMeta, "db."+dbcr.Name)
+		if err := r.Update(ctx, dbcr); err != nil {
+			log.Error(err, "error resource updating")
 			return r.manageError(ctx, dbcr, err, true, phase)
 		}
 	}

--- a/internal/helpers/kube/kube.go
+++ b/internal/helpers/kube/kube.go
@@ -70,6 +70,11 @@ func (kh *KubeHelper) ModifyObject(ctx context.Context, obj client.Object) error
 func (kh *KubeHelper) HandleDelete(ctx context.Context, obj client.Object) error {
 	// If object is not used by the caller, we shouldn't edit it when a caller is removed
 	if err := kh.Cli.Get(ctx, types.NamespacedName{Namespace: obj.GetNamespace(), Name: obj.GetName()}, obj); err != nil {
+		// Nothing to release/orphan if it's already gone. Returning nil keeps
+		// deletion idempotent so a finalizer waiting on this handler can proceed.
+		if k8serrors.IsNotFound(err) {
+			return nil
+		}
 		return err
 	}
 	if !kh.IsUsedByCaller(obj) {
@@ -81,6 +86,13 @@ func (kh *KubeHelper) HandleDelete(ctx context.Context, obj client.Object) error
 		)
 	}
 	obj = kh.DeleteUsedByLabels(obj)
+	// When the caller opts out of cleanup, strip our ownerReference so the
+	// garbage collector orphans (keeps) the object instead of cascade-deleting
+	// it together with the owner CR. With cleanup enabled the ownerReference is
+	// left in place, so the GC removes the object once the owner is gone.
+	if !kh.Caller.IsCleanup() {
+		obj = kh.SetOwnerReference(obj, metav1.OwnerReference{})
+	}
 	if err := kh.Cli.Update(ctx, obj); err != nil {
 		return err
 	}
@@ -198,19 +210,24 @@ func (kh *KubeHelper) DeleteUsedByLabels(obj client.Object) client.Object {
 }
 
 func (kh *KubeHelper) BuildOwnerReference() metav1.OwnerReference {
-	ownership := metav1.OwnerReference{}
-	// If cleanup is true, all the objects that are created by db-operator should be owned by the database object,
-	//  so they are removed when database is removed
-	if kh.Caller.IsCleanup() {
-		APIVersion := fmt.Sprintf("%s/%s", kh.Caller.GetObjectKind().GroupVersionKind().Group, kh.Caller.GetObjectKind().GroupVersionKind().Version)
-		ownership = metav1.OwnerReference{
-			APIVersion: APIVersion,
-			Kind:       kh.Caller.GetObjectKind().GroupVersionKind().Kind,
-			Name:       kh.Caller.GetName(),
-			UID:        kh.Caller.GetUID(),
-		}
+	// Generated objects are always owned by the caller CR so that ArgoCD
+	// discovers them as part of the deploy (its resource tree is built from
+	// ownerReferences). Cascade garbage-collection is decoupled from this in
+	// HandleDelete: when the caller opts out of cleanup, the ownerReference is
+	// stripped on deletion so the object is orphaned (preserved) instead.
+	//
+	// A cluster-scoped caller (DbInstance) must never own a namespaced object
+	// — Kubernetes rejects such ownerReferences — so skip it in that case.
+	if kh.Caller.GetNamespace() == "" {
+		return metav1.OwnerReference{}
 	}
-	return ownership
+	APIVersion := fmt.Sprintf("%s/%s", kh.Caller.GetObjectKind().GroupVersionKind().Group, kh.Caller.GetObjectKind().GroupVersionKind().Version)
+	return metav1.OwnerReference{
+		APIVersion: APIVersion,
+		Kind:       kh.Caller.GetObjectKind().GroupVersionKind().Kind,
+		Name:       kh.Caller.GetName(),
+		UID:        kh.Caller.GetUID(),
+	}
 }
 
 const (

--- a/internal/helpers/kube/kube_suite_test.go
+++ b/internal/helpers/kube/kube_suite_test.go
@@ -168,7 +168,16 @@ var _ = Describe("KubeHelpers test", func() {
 				consts.USED_BY_NAME_LABEL_KEY: database.GetName(),
 			}
 			Expect(secretCopy.GetLabels()).To(Equal(expectedLabels))
-			Expect(secretCopy.GetOwnerReferences()).To(BeEmpty())
+			// Ownership is decoupled from cleanup: the object is always owned by
+			// the caller (so ArgoCD sees it); preservation happens on delete.
+			Expect(secretCopy.GetOwnerReferences()).To(Equal([]metav1.OwnerReference{
+				{
+					APIVersion: database.APIVersion,
+					Kind:       database.Kind,
+					Name:       database.Name,
+					UID:        database.UID,
+				},
+			}))
 		})
 
 		It("Used by the caller, no cleanup", func() {
@@ -189,7 +198,14 @@ var _ = Describe("KubeHelpers test", func() {
 			err = kh.Update(ctx, secretCopy)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(secretCopy.GetLabels()).To(Equal(usedByLabels))
-			Expect(secretCopy.GetOwnerReferences()).To(BeEmpty())
+			Expect(secretCopy.GetOwnerReferences()).To(Equal([]metav1.OwnerReference{
+				{
+					APIVersion: database.APIVersion,
+					Kind:       database.Kind,
+					Name:       database.Name,
+					UID:        database.UID,
+				},
+			}))
 		})
 		It("Not used by any, with cleanup", func() {
 			secretName := "suite-3-test-3"
@@ -371,6 +387,57 @@ var _ = Describe("KubeHelpers test", func() {
 			secretCopy.SetLabels(usedByLabels)
 			err = kh.HandleDelete(ctx, secretCopy)
 			Expect(err).To(HaveOccurred())
+		})
+		It("Cleanup disabled orphans the object (owner ref stripped)", func() {
+			secretName := "suite-5-test-4"
+			databaseCopy := database.DeepCopy()
+			databaseCopy.Spec.Cleanup = false
+			rec := events.NewFakeRecorder(1)
+			kh := kube.NewKubeHelper(k8sClient, rec, databaseCopy)
+
+			secretCopy := secret.DeepCopy()
+			secretCopy.SetName(secretName)
+			secretCopy.SetLabels(map[string]string{
+				consts.USED_BY_KIND_LABEL_KEY: databaseCopy.GetObjectKind().GroupVersionKind().Kind,
+				consts.USED_BY_NAME_LABEL_KEY: databaseCopy.GetName(),
+			})
+			secretCopy.SetOwnerReferences([]metav1.OwnerReference{kh.BuildOwnerReference()})
+			Expect(kh.Cli.Create(ctx, secretCopy)).To(Succeed())
+
+			Expect(kh.HandleDelete(ctx, secretCopy)).To(Succeed())
+
+			fetched := &corev1.Secret{}
+			Expect(kh.Cli.Get(ctx, types.NamespacedName{Namespace: secretCopy.GetNamespace(), Name: secretName}, fetched)).To(Succeed())
+			Expect(fetched.GetOwnerReferences()).To(BeEmpty())
+		})
+		It("Cleanup enabled keeps the owner ref so the GC can cascade", func() {
+			secretName := "suite-5-test-5"
+			databaseCopy := database.DeepCopy()
+			databaseCopy.Spec.Cleanup = true
+			rec := events.NewFakeRecorder(1)
+			kh := kube.NewKubeHelper(k8sClient, rec, databaseCopy)
+
+			secretCopy := secret.DeepCopy()
+			secretCopy.SetName(secretName)
+			secretCopy.SetLabels(map[string]string{
+				consts.USED_BY_KIND_LABEL_KEY: databaseCopy.GetObjectKind().GroupVersionKind().Kind,
+				consts.USED_BY_NAME_LABEL_KEY: databaseCopy.GetName(),
+			})
+			secretCopy.SetOwnerReferences([]metav1.OwnerReference{kh.BuildOwnerReference()})
+			Expect(kh.Cli.Create(ctx, secretCopy)).To(Succeed())
+
+			Expect(kh.HandleDelete(ctx, secretCopy)).To(Succeed())
+
+			fetched := &corev1.Secret{}
+			Expect(kh.Cli.Get(ctx, types.NamespacedName{Namespace: secretCopy.GetNamespace(), Name: secretName}, fetched)).To(Succeed())
+			Expect(fetched.GetOwnerReferences()).To(HaveLen(1))
+		})
+		It("Already-deleted object is a no-op", func() {
+			rec := events.NewFakeRecorder(1)
+			kh := kube.NewKubeHelper(k8sClient, rec, database)
+			secretCopy := secret.DeepCopy()
+			secretCopy.SetName("suite-5-test-6-missing")
+			Expect(kh.HandleDelete(ctx, secretCopy)).To(Succeed())
 		})
 	})
 	Context("Test the main handler", func() {

--- a/internal/helpers/kube/kube_test.go
+++ b/internal/helpers/kube/kube_test.go
@@ -127,12 +127,28 @@ func TestBuildOwnerReferenceCleanup(t *testing.T) {
 }
 
 func TestBuildOwnerReferenceNotCleanup(t *testing.T) {
+	// Ownership is decoupled from cleanup: a namespaced caller always owns its
+	// generated objects so ArgoCD sees them. Preservation is handled on delete.
 	databaseCopy := database.DeepCopy()
 	databaseCopy.Spec.Cleanup = false
 	kh := &kube.KubeHelper{Caller: databaseCopy}
 	actual := kh.BuildOwnerReference()
-	expected := metav1.OwnerReference{}
+	expected := metav1.OwnerReference{
+		APIVersion: database.APIVersion,
+		Kind:       database.Kind,
+		Name:       database.Name,
+		UID:        database.UID,
+	}
 	assert.Equal(t, expected, actual)
+}
+
+func TestBuildOwnerReferenceClusterScopedCaller(t *testing.T) {
+	// A cluster-scoped caller (empty namespace, e.g. DbInstance) must not own a
+	// namespaced object — Kubernetes rejects such references.
+	databaseCopy := database.DeepCopy()
+	databaseCopy.Namespace = ""
+	kh := &kube.KubeHelper{Caller: databaseCopy}
+	assert.Equal(t, metav1.OwnerReference{}, kh.BuildOwnerReference())
 }
 
 func TestSetOwnerReferenceCleanupOnly(t *testing.T) {
@@ -186,6 +202,7 @@ func TestSetOwnerReferenceCleanupExtra(t *testing.T) {
 }
 
 func TestSetOwnerReferenceNotCleanupOnly(t *testing.T) {
+	// Even without cleanup the caller owns the object (for ArgoCD visibility).
 	databaseCopy := database.DeepCopy()
 	databaseCopy.Spec.Cleanup = false
 	kh := &kube.KubeHelper{Caller: databaseCopy}
@@ -194,7 +211,16 @@ func TestSetOwnerReferenceNotCleanupOnly(t *testing.T) {
 	ownerRef := kh.BuildOwnerReference()
 	actual := kh.SetOwnerReference(secretCopy, ownerRef)
 
-	assert.Equal(t, []metav1.OwnerReference{}, actual.GetOwnerReferences())
+	expected := []metav1.OwnerReference{
+		{
+			APIVersion: database.APIVersion,
+			Kind:       database.Kind,
+			Name:       database.Name,
+			UID:        database.UID,
+		},
+	}
+
+	assert.Equal(t, expected, actual.GetOwnerReferences())
 }
 
 func TestSetOwnerReferenceNotCleanupExtra(t *testing.T) {
@@ -217,7 +243,12 @@ func TestSetOwnerReferenceNotCleanupExtra(t *testing.T) {
 	ownerRef := kh.BuildOwnerReference()
 	actual := kh.SetOwnerReference(secretCopy, ownerRef)
 
-	expected := existingOwnerRef
+	expected := append(existingOwnerRef, metav1.OwnerReference{
+		APIVersion: database.APIVersion,
+		Kind:       database.Kind,
+		Name:       database.Name,
+		UID:        database.UID,
+	})
 
 	assert.Equal(t, expected, actual.GetOwnerReferences())
 }


### PR DESCRIPTION
## Problem

Objects the operator generates at runtime (credentials Secret, info ConfigMap, proxy CM/Deployment/Service, ServiceMonitor, instance-access Secret) were only given an `ownerReference` when `spec.cleanup: true` (`BuildOwnerReference` gated on `IsCleanup()`). For the common `cleanup: false` case — e.g. deletion-protected databases — there was **no ownerReference**, so ArgoCD (whose resource tree is built from ownerReferences) could not associate the generated objects with the owning Application and never showed them as part of the deploy.

## Change

- **`BuildOwnerReference`**: drop the `IsCleanup()` gate — a namespaced caller now **always** owns its generated objects (ArgoCD visibility). Guard the cluster-scoped `DbInstance` caller (empty namespace): Kubernetes rejects a cluster-scoped owner on a namespaced object.
- **`HandleDelete`**: decouple cascade-GC from ownership. When the caller opts out of cleanup (`cleanup: false`), **strip our ownerReference on delete** so the garbage collector *orphans* (preserves) the Secret/ConfigMap instead of cascade-deleting it. `NotFound` is now a no-op so a waiting finalizer can proceed.
- **`database_controller.handleDbDelete`**: remove the `db.<name>` finalizer **only after** every generated object has been handled — eliminates a GC race where the owner could be deleted (cascading to dependents) before they are orphaned. (`DbUser` already deletes its secret before removing its finalizer.)

Net effect: ArgoCD sees operator-generated objects as part of the deploy (prune-safe, via ownerRefs), and `cleanup: false` still guarantees the Secret/ConfigMap survive deletion of the owning CR.

## Tests

- Unit contract tests updated to the cleanup-decoupled ownership; new test for the cluster-scoped guard.
- envtest specs added: `cleanup: false` orphans the object (ownerRef stripped), `cleanup: true` keeps the ownerRef for the GC to cascade, and already-deleted is a no-op.
- `task lint` → 0 issues; `task unit-test` + `task kubernetes-test` (kube suite 25/25) green.

No API/CRD change — reuses the existing `cleanup` field. A new image release (`-dc10`) is all consumers need.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed database deletion to properly clean up all associated resources (credentials, access secrets, proxy resources, configuration maps, and backup jobs) before finalizing deletion, preventing resource orphaning
  * Enhanced resource deletion handling to gracefully manage Kubernetes objects that are already deleted and improve resource ownership management during cleanup operations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/datacosmos-br/db-operator/pull/77?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->